### PR TITLE
Update summernote.js

### DIFF
--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -1879,7 +1879,7 @@
     if (options && options.tooltip) {
       $node.attr({
         title: options.tooltip,
-        "aria-label": options.tooltip
+        'aria-label': options.tooltip
       }).tooltip({
         container: 'body',
         trigger: 'hover',
@@ -5894,8 +5894,8 @@
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
       var body = '<div class="form-group">' +
-                   '<label id="textToDisplay">' + lang.link.textToDisplay + '</label>' +
-                   '<input class="note-link-text form-control" type="text" />' +
+                   '<label id="Display">' + lang.link.textToDisplay + '</label>' +
+                   '<input class="note-link-text form-control" type="text" aria-labelledby="Display" />' +
                  '</div>' +
                  '<div class="form-group">' +
                    '<label id="url">' + lang.link.url + '</label>' +
@@ -5903,7 +5903,7 @@
                  '</div>' +
                  (!options.disableLinkTarget ?
                    '<div class="checkbox">' +
-                     '<label id="openInNewWindow">' + '<input type="checkbox" aria-labelledby="openInNewWindow" checked> ' + lang.link.openInNewWindow + '</label>' +
+                     '<label id="New">' + '<input type="checkbox" checked aria-labelledby="New"> ' + lang.link.openInNewWindow + '</label>' +
                    '</div>' : ''
                  );
       var footer = '<button href="#" class="btn btn-primary note-link-btn disabled" disabled>' + lang.link.insert + '</button>';
@@ -6120,8 +6120,8 @@
       }
 
       var body = '<div class="form-group note-group-select-from-files">' +
-                   '<label id="selectFromFiles">' + lang.image.selectFromFiles + '</label>' +
-                   '<input class="note-image-input form-control" type="file" name="files" accept="image/*" multiple="multiple" aria-labelledby="selectFromFiles" />' +
+                   '<label id="Files">' + lang.image.selectFromFiles + '</label>' +
+                   '<input class="note-image-input form-control" type="file" name="files" accept="image/*" multiple="multiple" aria-labelledby="Files" />' +
                    imageLimitation +
                  '</div>' +
                  '<div class="form-group note-group-image-url" style="overflow:auto;">' +


### PR DESCRIPTION
summernote pull request:

#### What does this PR do?

- It adds an aria-label to all of the buttons on summernote.


var codable = renderer.create('<textarea class="note-codable" aria-label="codable"/>');

#### How should this be manually tested?

- Download the wave tool plugin from google chrome and run the wave tool against summernote and you will see the aria-label being implemented. 
-aria-label is not visible to the human eye only screen readers can pick it up. The wave tool makes it visible for us.  

#### Any background context you want to provide?

- Need to meet 508 compliance and this was holding me back.



I used the wave tool plugin on google chrome fixed all of the errors that popped up with summernote that indicated that the button tag does not have any content within it.
